### PR TITLE
Dynamically created playbook for arbitrary ansible roles

### DIFF
--- a/cmd/run
+++ b/cmd/run
@@ -17,6 +17,7 @@ strap::lib::import fs || source ../lib/fs.sh
 strap::lib::import os || source ../lib/os.sh
 strap::lib::import pkgmgr || source ../lib/pkgmgr.sh
 strap::lib::import pkg || source ../lib/pkg.sh
+strap::lib::import python || source ../lib/python.sh
 strap::lib::import ansible || source ../lib/ansible.sh
 
 STRAP_SCRIPT="${STRAP_SCRIPT:-}" && [[ -z "$STRAP_SCRIPT" ]] && echo "STRAP_SCRIPT is not set" && exit 1
@@ -199,16 +200,21 @@ strap::ok
 #############################################################
 
 strap::bot 'Package Manager'
-
 strap::pkgmgr::init
+
+#############################################################
+# Python & Pip
+#############################################################
+
+strap::bot 'Python & Pip'
+strap::python::install
 
 #############################################################
 # Ansible
 #############################################################
 
 strap::bot 'Ansible'
-
-strap::pkgmgr::pkg::ensure ansible
+strap::ansible::install
 
 #############################################################
 # Git & GitHub:
@@ -232,12 +238,6 @@ if [[ "$(strap::pkgmgr::id)" == 'yum' ]]; then
     sudo yum -y erase git >/dev/null 2>&1 || true
     strap::ok
   fi
-#  git_exe_path="$(git command -v 2>/dev/null || true)"
-#  if [[ -n "$git_exe_path" ]]; then # git is installed.  See if it came from git2u, which is our required package
-#    if ! rpm -qf "$git_exe_path" | grep git2u >/dev/null 2>&1; then
-#      #uninstall incompatible
-#    fi
-#  fi
 fi
 strap::pkgmgr::pkg::ensure "$git_package_name"
 
@@ -345,12 +345,14 @@ if [[ "${#STRAP_RUN_HOOK_PACKAGES[@]}" -gt 0 ]]; then
 
   strap::bot "Run Hook Packages"
 
-  # We use yq or python yaml (whichever is available) to convert yaml to json and then use jq to read package metadata
-  if strap::os::is_mac; then
-    strap::pkgmgr::pkg::ensure yq
-  else
-    strap::pkgmgr::pkg::ensure pyyaml
-  fi
+  # Ensure pyyaml is available so we can read strap package.yml metadata files:
+  strap::running "Ensuring strap virtualenv pyyaml"
+  set +e
+  output="$(python -m pip install --upgrade pyyaml 2>&1)"
+  retval="$?"
+  set -e
+  [[ "${retval}" -eq 0 ]] || strap::abort "Error: ${output}"
+  strap::ok
 
   # ensure packages exist, or download and are valid:
   for package_id in "${STRAP_RUN_HOOK_PACKAGES[@]}"; do

--- a/lib/brew.sh
+++ b/lib/brew.sh
@@ -26,7 +26,7 @@ strap::brew::init() {
     brew update >/dev/null
     brew upgrade
     strap::ok
-    strap::running "Checking Homebrew cleanup"
+    strap::running "Ensuring Homebrew cleanup"
     brew cleanup >/dev/null
   else
     strap::action "Installing Homebrew"
@@ -44,7 +44,8 @@ strap::brew::init() {
   strap::ok
 
   STRAP_HOMEBREW_PREFIX="$(brew --prefix)"
-  ! strap::path::contains "$STRAP_HOMEBREW_PREFIX/bin" && export PATH="$STRAP_HOMEBREW_PREFIX/bin:$PATH"
+  strap::path::contains "${STRAP_HOMEBREW_PREFIX}/sbin" || export PATH="${STRAP_HOMEBREW_PREFIX}/sbin:${PATH}"
+  strap::path::contains "${STRAP_HOMEBREW_PREFIX}/bin" || export PATH="${STRAP_HOMEBREW_PREFIX}/bin:${PATH}"
 
   strap::running "Ensuring Homebrew \$PATH entries"
   local filename="100.homebrew.sh"

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -26,6 +26,7 @@ strap::os::distro() {
   local distro=''
   [[ "$STRAP_OS" == 'mac' ]] && distro='darwin'
   [[ -z "$distro" ]] && [[ -f '/etc/ubuntu-release' ]] && distro='ubuntu'
+  [[ -z "$distro" ]] && [[ -f '/etc/fedora-release' ]] && distro='fedora'
   [[ -z "$distro" ]] && [[ -f '/etc/centos-release' ]] && distro='centos'
   [[ -z "$distro" ]] && [[ -f '/etc/redhat-release' ]] && distro='redhat'
   [[ -z "$distro" ]] && distro='linux' # default

--- a/lib/pkg.sh
+++ b/lib/pkg.sh
@@ -141,12 +141,7 @@ strap::pkg::yaml::path() {
 strap::pkg::yaml::jq() {
   local -r file="${1:-}" && strap::assert "[ -f $file ]" '$1 must be a Strap package.yml file'
   local -r query="${2:-}" && strap::assert::has_length "$query" '$2 must be a jq query string'
-
-  if command -v yq >/dev/null; then
-    yq r -j "$file" | jq -r "$query"
-  else
-    python -c 'import sys, yaml, json; json.dump(yaml.load(sys.stdin), sys.stdout, indent=2)' < "$file" | jq -r "$query"
-  fi
+  python -c 'import sys, yaml, json; json.dump(yaml.load(sys.stdin), sys.stdout, indent=2)' < "$file" | jq -r "$query"
 }
 
 strap::pkg::yaml::hook::path() {

--- a/lib/python.sh
+++ b/lib/python.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+if ! command -v strap::lib::import >/dev/null; then
+  echo "This file is not intended to be run or sourced outside of a strap execution context." >&2
+  [[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 1 || exit 1 # if sourced, return 1, else running as a command, so exit
+fi
+strap::lib::import logging || . logging.sh
+strap::lib::import lang || . lang.sh
+strap::lib::import fs || . fs.sh
+strap::lib::import git || . git.sh
+strap::lib::import os || . os.sh
+strap::lib::import pkgmgr || . pkgmgr.sh
+
+STRAP_HOME="${STRAP_HOME:-}"; [[ -n "$STRAP_HOME" ]] || { echo "STRAP_HOME is not set" >&2; exit 1; }
+STRAP_USER_HOME="${STRAP_USER_HOME:-}"; [[ -n "$STRAP_USER_HOME" ]] || { echo "STRAP_USER_HOME is not set" >&2; exit 1; }
+
+set -a
+
+function strap::python::install() {
+
+  local distro= pkgname='python'
+
+  distro="$(strap::os::distro)"
+
+  case "${distro}" in
+    darwin)        pkgname='python' ;;
+    redhat|centos) pkgname='python36' ;;
+    fedora)        pkgname='python37' ;;
+    *)
+      strap::abort 'Unrecognized operating system - cannot install python3. Please open an issue with the Strap team.'
+      ;;
+  esac
+
+  strap::pkgmgr::pkg::ensure "${pkgname}"
+  if ! command -v python3 >/dev/null 2>&1; then
+    strap::abort "Python 3 could not be installed."
+  fi
+
+  if ! python3 -m pip --version >/dev/null 2>&1; then # must be linux because homebrew includes pip automatically
+    strap::pkgmgr::pkg::ensure "${pkgname}-pip"
+  fi
+}
+
+set +a

--- a/lib/yum.sh
+++ b/lib/yum.sh
@@ -27,7 +27,7 @@ strap::yum::init() {
   if ! strap::yum::pkg::is_installed 'epel-release'; then # needed for jq and maybe others
     strap::yum::pkg::install 'epel-release'
   fi
-  if ! strap::yum::pkg::is_installed 'ius-release'; then # needed for git2u (up to date git and git-credential-libsecret)
+  if ! strap::yum::pkg::is_installed 'ius-release'; then # needed for git2u (up to date git and git-credential-libsecret) and python3
     sudo yum -y install 'https://centos7.iuscommunity.org/ius-release.rpm'
   fi
 }


### PR DESCRIPTION
- Ensured ansible was run not as a system package, but as a pip package.  This guarantees consistency across platforms since the only system package pre-requisite is now python 3.6 or later.

- Enabled arbitrary ansible role execution with --with-ansible-role arguments by dynamically creating and executing a localhost playbook.